### PR TITLE
Fix issue 47, add support for library keyword from solidity

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/eris-ltd/lllc-server",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
 	],

--- a/cache_test.go
+++ b/cache_test.go
@@ -22,9 +22,11 @@ func copyFile(src, dst string) error {
 
 func testCache(t *testing.T) {
 	ClearCaches()
-	code, _, err := Compile("tests/test-inc1.lll")
-	if err != nil {
-		t.Fatal(err)
+
+	resp := Compile("tests/test-inc1.lll", "")
+	code := resp.Objects[0].Bytecode
+	if resp.Error != "" {
+		t.Fatal(fmt.Errorf(resp.Error))
 	}
 	fmt.Printf("%x\n", code)
 	copyFile("tests/test-inc1.lll", path.Join(common.LllcScratchPath, "test-inc1.lll"))
@@ -32,9 +34,10 @@ func testCache(t *testing.T) {
 	copyFile("tests/test-inc4.lll", path.Join(common.LllcScratchPath, "test-inc3.lll"))
 	cur, _ := os.Getwd()
 	os.Chdir(common.LllcScratchPath)
-	code2, _, err := Compile(path.Join(common.LllcScratchPath, "test-inc1.lll"))
-	if err != nil {
-		t.Fatal(err)
+	resp = Compile(path.Join(common.LllcScratchPath, "test-inc1.lll"), "")
+	code2 := resp.Objects[0].Bytecode
+	if resp.Error != "" {
+		t.Fatal(fmt.Errorf(resp.Error))
 	}
 	fmt.Printf("%x\n", code2)
 	if bytes.Compare(code, code2) == 0 {
@@ -56,9 +59,10 @@ func TestCacheRemote(t *testing.T) {
 func TestSimple(t *testing.T) {
 	ClearCaches()
 	SetLanguageNet("lll", false)
-	code, _, err := Compile("tests/test-inc1.lll")
-	if err != nil {
-		t.Fatal(err)
+	resp := Compile("tests/test-inc1.lll", "")
+	code := resp.Objects[0].Bytecode
+	if resp.Error != "" {
+		t.Fatal(fmt.Errorf(resp.Error))
 	}
 	fmt.Printf("%x\n", code)
 }

--- a/client.go
+++ b/client.go
@@ -1,14 +1,13 @@
 package compilers
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path"
 
 	"github.com/eris-ltd/eris-compilers/Godeps/_workspace/src/github.com/eris-ltd/common/go/common"
 )
 
-// Client cache location in eris tree
+// ClientCache location in eris tree
 var ClientCache = path.Join(common.LllcScratchPath, "client")
 
 // filename is either a filename or literal code
@@ -23,19 +22,19 @@ func resolveCode(filename string, literal bool) (code []byte, err error) {
 }
 
 // send compile request to server or compile directly
-func (c *CompileClient) compileRequest(req *Request) (respJ *Response, err error) {
+func (c *CompileClient) compileRequest(req *Request) (resp *Response, err error) {
 	if c.config.Net {
 		logger.Infof("Compiling code remotely =>\t%s\n", c.config.URL)
-		respJ, err = requestResponse(req)
+		resp, err = requestResponse(req)
 	} else {
 		logger.Infoln("Compiling code locally.")
-		respJ = compileServerCore(req)
+		resp = compileServerCore(req)
 	}
 	return
 }
 
-// Takes a dir and some code, replaces all includes, checks cache, compiles, caches
-func (c *CompileClient) Compile(dir string, code []byte) (*Response, error) {
+// Compile takes a dir and some code, replaces all includes, checks cache, compiles, caches
+func (c *CompileClient) Compile(dir string, code []byte, libraries string) (*Response, error) {
 	// replace includes with hash of included contents and add those contents to Includes (recursive)
 	var includes = make(map[string][]byte)     // hashes to code
 	var includeNames = make(map[string]string) //hashes before replace to hashes after
@@ -49,71 +48,73 @@ func (c *CompileClient) Compile(dir string, code []byte) (*Response, error) {
 
 	// go through all includes, check if they have changed
 	hash, cached := c.checkCached(code, includes)
+
 	logger.Debugf("Files [Hash, Cached?] =>\t%s:%v\n", hash, cached)
 
 	// if everything is cached, no need for request
 	if cached {
+		// TODO: need to return all contracts/libs tied to the original src file
 		return c.cachedResponse(hash)
 	}
-	req := NewRequest(code, includes, c.Lang())
+	req := NewRequest(code, includes, c.Lang(), libraries)
 
 	// response struct (returned)
-	respJ, err := c.compileRequest(req)
+	resp, err := c.compileRequest(req)
+
 	if err != nil {
 		return nil, err
 	}
 
-	if respJ.Error == "" {
-		// fill in cached values, cache new values
-		if err := c.cacheFile(respJ.Bytecode, hash); err != nil {
-			return nil, err
-		}
-		if err := c.cacheFile([]byte(respJ.ABI), hash+"-abi"); err != nil {
-			return nil, err
+	if resp.Error == "" {
+		for _, r := range resp.Objects {
+			// fill in cached values, cache new values
+			if r.Bytecode != nil {
+				if err := c.cacheFile(r.Bytecode, hash, r.Objectname, "bin"); err != nil {
+					return nil, err
+				}
+				if err := c.cacheFile([]byte(r.ABI), hash, r.Objectname, "abi"); err != nil {
+					return nil, err
+				}
+			}
 		}
 	}
 
-	return respJ, nil
+	return resp, nil
 }
 
 // create a new compiler for the language and compile the code
-func compile(code []byte, lang, dir string) ([]byte, string, error) {
+func compile(filename string, code []byte, lang, dir string, libraries string) *Response {
 	c, err := NewCompileClient(lang)
 	if err != nil {
-		return nil, "", err
+		return NewResponse("", nil, "", err)
 	}
-	r, err := c.Compile(dir, code)
+	r, err := c.Compile(dir, code, libraries)
 	if err != nil {
-		return nil, "", err
+		return NewResponse("", nil, "", err)
 	}
-	b := r.Bytecode
-	if r.Error != "" {
-		err = fmt.Errorf(r.Error)
-	} else {
-		err = nil
-	}
-	return b, r.ABI, err
+
+	return r
 }
 
 // Compile a file and resolve includes
-func Compile(filename string) ([]byte, string, error) {
+func Compile(filename string, libraries string) *Response {
 	lang, err := LangFromFile(filename)
 	if err != nil {
-		return nil, "", err
+		return NewResponse("", nil, "", err)
 	}
 
 	logger.Infof("Language to use =>\t\t%s\n", lang)
 
 	code, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, "", err
+		return NewResponse("", nil, "", err)
 
 	}
 	dir := path.Dir(filename)
-	return compile(code, lang, dir)
+	return compile(filename, code, lang, dir, libraries)
 }
 
 // Compile a literal piece of code
-func CompileLiteral(code string, lang string) ([]byte, string, error) {
-	return compile([]byte(code), lang, common.LllcScratchPath)
+func CompileLiteral(code string, lang string) *Response {
+	return compile("Literal", []byte(code), lang, common.LllcScratchPath, "")
 }

--- a/compile.go
+++ b/compile.go
@@ -34,7 +34,7 @@ func (l LangConfig) Ext(h string) string {
 }
 
 // Fill in the filename and return the command line args
-func (l LangConfig) Cmd(file string, includes []string) (args []string) {
+func (l LangConfig) Cmd(file string, includes []string, libraries string) (args []string) {
 	for _, s := range l.CompileCmd {
 		if s == "_" {
 			args = append(args, file)
@@ -43,6 +43,10 @@ func (l LangConfig) Cmd(file string, includes []string) (args []string) {
 		} else {
 			args = append(args, s)
 		}
+	}
+	if libraries != "" {
+		args = append(args, "--libraries ")
+		args = append(args, libraries)
 	}
 	logger.Debugf("Command Compiled =>\t\t%v\n", args)
 	return
@@ -120,31 +124,8 @@ var Languages = map[string]LangConfig{
 		},
 		CompileCmd: []string{
 			"/usr/bin/solc",
-			"--bin",
+			"--combined-json", "bin", "abi",
 			"_",
-			"imports",
-			"|",
-			"grep",
-			"Binary",
-			"-A1",
-			"|",
-			"tail",
-			"-n",
-			"1",
-		},
-		AbiCmd: []string{
-			"/usr/bin/solc",
-			"--abi",
-			"_",
-			"imports",
-			"|",
-			"grep",
-			"ABI",
-			"-A1",
-			"|",
-			"tail",
-			"-n",
-			"1",
 		},
 	},
 }

--- a/files.go
+++ b/files.go
@@ -120,19 +120,40 @@ func (c *CompileClient) checkCached(code []byte, includes map[string][]byte) (st
 
 // return cached byte code as a response
 func (c *CompileClient) cachedResponse(hash string) (*Response, error) {
-	f := path.Join(ClientCache, c.Ext(hash))
-	b, err := ioutil.ReadFile(f)
-	if err != nil {
-		return nil, err
+	d := path.Join(ClientCache, c.Ext(hash))
+	var resp *Response
+	files, _ := ioutil.ReadDir(d)
+	respItemArray := make([]ResponseItem, len(files))
+	i := 0
+	for _, f := range files {
+		fileName := f.Name()
+		b, err := ioutil.ReadFile(path.Join(d, fileName, "bin"))
+		if err != nil {
+			return nil, err
+		}
+		abi, _ := ioutil.ReadFile(path.Join(d, fileName, "abi"))
+
+		respItem := ResponseItem{
+			Objectname: fileName,
+			Bytecode:   b,
+			ABI:        string(abi),
+		}
+		respItemArray[i] = respItem
+		i++
+
 	}
-	f = path.Join(ClientCache, c.Ext(hash+"-abi"))
-	abi, _ := ioutil.ReadFile(f)
-	return NewResponse(b, string(abi), nil), nil
+	resp = &Response{
+		Objects: respItemArray,
+		Error:   "",
+	}
+
+	return resp, nil
 }
 
 // cache a file to disk
-func (c *CompileClient) cacheFile(b []byte, hash string) error {
-	f := path.Join(ClientCache, c.Ext(hash))
+func (c *CompileClient) cacheFile(b []byte, hash string, name string, ext string) error {
+	f := path.Join(ClientCache, c.Ext(hash), name, ext)
+	os.MkdirAll(path.Dir(f), 0744)
 	if b != nil {
 		if err := ioutil.WriteFile(f, b, 0644); err != nil {
 			return err
@@ -142,22 +163,21 @@ func (c *CompileClient) cacheFile(b []byte, hash string) error {
 }
 
 // check cache for server
-func checkCache(hash []byte) (*Response, error) {
-	f := path.Join(ClientCache, hex.EncodeToString(hash))
+func checkCache(objectName string) (*Response, error) {
+	f := path.Join(ServerCache, objectName)
 	if _, err := os.Stat(f); err == nil {
 		b, err := ioutil.ReadFile(f)
 		if err != nil {
 			return nil, err
 		}
-		f += "-abi"
-		abi, _ := ioutil.ReadFile(f)
-		return NewResponse(b, string(abi), nil), nil
+		abi, _ := ioutil.ReadFile(f + "-abi")
+		return NewResponse(objectName, b, string(abi), nil), nil
 	}
 	return nil, fmt.Errorf("Not cached")
 }
 
-func cacheResult(hash, compiled []byte, docs string) {
-	f := path.Join(ClientCache, hex.EncodeToString(hash))
+func cacheResult(objectName string, compiled []byte, docs string) {
+	f := path.Join(ServerCache, objectName)
 	ioutil.WriteFile(f, compiled, 0600)
 	ioutil.WriteFile(f+"-abi", []byte(docs), 0600)
 }

--- a/net.go
+++ b/net.go
@@ -13,15 +13,21 @@ import (
 type Request struct {
 	ScriptName string            `json:name"`
 	Language   string            `json:"language"`
-	Script     []byte            `json:"script"`   // source code file bytes
-	Includes   map[string][]byte `json:"includes"` // filename => source code file bytes
+	Script     []byte            `json:"script"`    // source code file bytes
+	Includes   map[string][]byte `json:"includes"`  // filename => source code file bytes
+	Libraries  string            `json:"libraries"` // string of libName:LibAddr separated by comma
 }
 
 // Compile response object
+type ResponseItem struct {
+	Objectname string `json:"objectname"`
+	Bytecode   []byte `json:"bytecode"`
+	ABI        string `json:"abi"` // json encoded
+}
+
 type Response struct {
-	Bytecode []byte `json:"bytecode"`
-	ABI      string `json:"abi"` // json encoded
-	Error    string `json:"error"`
+	Objects []ResponseItem `json:"objects"`
+	Error   string         `json:"error"`
 }
 
 // Proxy request object.
@@ -29,9 +35,10 @@ type Response struct {
 // If the source is a literal (rather than filename),
 // ProxyReq.Literal must be set to true and ProxyReq.Language must be provided
 type ProxyReq struct {
-	Source   string `json:"source"`
-	Literal  bool   `json:"literal"`
-	Language string `json:"language"`
+	Source    string `json:"source"`
+	Literal   bool   `json:"literal"`
+	Language  string `json:"language"`
+	Libraries string `json:"libraries"` // string of libName:LibAddr separated by comma
 }
 
 type ProxyRes struct {
@@ -41,29 +48,37 @@ type ProxyRes struct {
 }
 
 // New Request object from script and map of include files
-func NewRequest(script []byte, includes map[string][]byte, lang string) *Request {
+func NewRequest(script []byte, includes map[string][]byte, lang string, libs string) *Request {
 	if includes == nil {
 		includes = make(map[string][]byte)
 	}
 	req := &Request{
-		Script:   script,
-		Includes: includes,
-		Language: lang,
+		Script:    script,
+		Includes:  includes,
+		Language:  lang,
+		Libraries: libs,
 	}
 	return req
 }
 
 // New response object from bytecode and an error
-func NewResponse(bytecode []byte, abi string, err error) *Response {
+func NewResponse(objectname string, bytecode []byte, abi string, err error) *Response {
 	e := ""
 	if err != nil {
 		e = err.Error()
 	}
 
+	respItem := ResponseItem{
+		Objectname: objectname,
+		Bytecode:   bytecode,
+		ABI:        abi}
+
+	respItemArray := make([]ResponseItem, 1)
+	respItemArray[0] = respItem
+
 	return &Response{
-		Bytecode: bytecode,
-		ABI:      abi,
-		Error:    e,
+		Objects: respItemArray,
+		Error:   e,
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -61,14 +61,12 @@ func ProxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var code []byte
-	var abi string
+	var resp *Response
 	if req.Literal {
-		code, abi, err = CompileLiteral(req.Source, req.Language)
+		resp = CompileLiteral(req.Source, req.Language)
 	} else {
-		code, abi, err = Compile(req.Source)
+		resp = Compile(req.Source, req.Libraries)
 	}
-	resp := NewProxyResponse(code, abi, err)
 
 	respJ, err := json.Marshal(resp)
 	if err != nil {
@@ -100,9 +98,12 @@ func CompileHandlerJs(w http.ResponseWriter, r *http.Request) {
 	if resp == nil {
 		return
 	}
-	code := resp.Bytecode
-	hexx := hex.EncodeToString(code)
-	w.Write([]byte(fmt.Sprintf(`{"bytecode": "%s"}`, hexx)))
+	respJ, err := json.Marshal(resp)
+	if err != nil {
+		logger.Errorln("failed to marshal", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	w.Write(respJ)
 }
 
 // read in the files from the request, compile them
@@ -137,19 +138,17 @@ func compileResponse(w http.ResponseWriter, r *http.Request) *Response {
 
 // core compile functionality. used by the server and locally to mimic the server
 func compileServerCore(req *Request) *Response {
-	var name string
 	lang := req.Language
 	compiler := Languages[lang]
 
 	c := req.Script
 	if c == nil || len(c) == 0 {
-		return NewResponse(nil, "", fmt.Errorf("No script provided"))
+		return NewResponse("", nil, "", fmt.Errorf("No script provided"))
 	}
 
-	// take sha2 of request object to get tmp filename
+	// take sha256 of request object to get tmp filename
 	hash := sha256.Sum256(c)
 	filename := path.Join(ServerCache, compiler.Ext(hex.EncodeToString(hash[:])))
-	name = filename
 
 	maybeCached := true
 
@@ -174,23 +173,23 @@ func compileServerCore(req *Request) *Response {
 
 	// check cache
 	if maybeCached {
-		r, err := checkCache(hash[:])
+		r, err := checkCache(filename) // TODO:  use checkCached?
 		if err == nil {
 			return r
 		}
 	}
 
-	var resp *Response
 	//compile scripts, return bytecode and error
-	compiled, docs, err := CompileWrapper(name, lang, includes)
+	resp := CompileWrapper(filename, lang, includes, req.Libraries)
 
 	// cache
-	if err == nil {
-		cacheResult(hash[:], compiled, docs)
+	if resp.Error == "" {
+		// iterate over the array
+		for _, r := range resp.Objects {
+			// TODO: cache results using the cacheFile?
+			cacheResult(r.Objectname, r.Bytecode, r.ABI)
+		}
 	}
-
-	resp = NewResponse(compiled, docs, err)
-
 	return resp
 }
 
@@ -241,7 +240,7 @@ func commandWrapper(tokens ...string) (string, error) {
 }
 
 // wrapper to cli
-func CompileWrapper(filename string, lang string, includes []string) ([]byte, string, error) {
+func CompileWrapper(filename string, lang string, includes []string, libraries string) *Response {
 	// we need to be in the same dir as the files for sake of includes
 	cur, _ := os.Getwd()
 	dir := path.Dir(filename)
@@ -249,7 +248,7 @@ func CompileWrapper(filename string, lang string, includes []string) ([]byte, st
 	filename = path.Base(filename)
 
 	if _, ok := Languages[lang]; !ok {
-		return nil, "", UnknownLang(lang)
+		return NewResponse(filename, nil, "", UnknownLang(lang))
 	}
 
 	os.Chdir(dir)
@@ -257,28 +256,61 @@ func CompileWrapper(filename string, lang string, includes []string) ([]byte, st
 		os.Chdir(cur)
 	}()
 
-	tokens := Languages[lang].Cmd(filename, includes)
+	tokens := Languages[lang].Cmd(filename, includes, libraries)
+
 	hexCode, err := commandWrapper(tokens...)
+
 	if err != nil {
 		logger.Errorln("Couldn't compile!!", err)
 		logger.Errorf("Command =>\t\t\t%v\n", tokens)
-		return nil, "", err
+		return NewResponse(filename, nil, "", err)
 	}
 
-	tokens = Languages[lang].Abi(filename, includes)
-	jsonAbi, err := commandWrapper(tokens...)
-	if err != nil {
-		logger.Errorln("Couldn't produce abi doc!!", err)
-		// we swallow this error, but maybe we shouldnt...
+	var resp *Response
+	// attempt to decode as a solc json return structure
+	solcResp := new(SolcResponse)
+
+	err = json.Unmarshal([]byte(hexCode), solcResp)
+
+	if err == nil {
+
+		respItemArray := make([]ResponseItem, 1)
+
+		for contract, item := range solcResp.Contracts {
+			b, err := hex.DecodeString(item.Bin)
+			if err == nil {
+				respItem := ResponseItem{
+					Objectname: contract,
+					Bytecode:   b,
+					ABI:        item.Abi,
+				}
+				respItemArray = append(respItemArray, respItem)
+			}
+		}
+
+		return &Response{
+			Objects: respItemArray,
+			Error:   "",
+		}
+	} else {
+		// if doesn't work, then not a solc response
+		tokens = Languages[lang].Abi(filename, includes)
+		jsonAbi, err := commandWrapper(tokens...)
+
+		if err != nil {
+			logger.Errorln("Couldn't produce abi doc!!", err)
+			// we swallow this error, but maybe we shouldnt...
+		}
+
+		b, err := hex.DecodeString(hexCode)
+		if err != nil {
+			// in that case, the bytecode is not valid, so it should be flagged.
+			resp = NewResponse(filename, nil, "", err)
+		} else {
+			resp = NewResponse(filename, b, jsonAbi, nil)
+		}
 	}
-
-	b, err := hex.DecodeString(hexCode)
-	if err != nil {
-
-		return nil, "", err
-	}
-
-	return b, jsonAbi, nil
+	return resp
 }
 
 // Start the compile server

--- a/solc.go
+++ b/solc.go
@@ -1,0 +1,13 @@
+package compilers
+
+// individual contract items
+type SolcItem struct {
+	Bin string `json:"bin"`
+	Abi string `json:"abi"`
+}
+
+// full solc response object
+type SolcResponse struct {
+	Contracts map[string]SolcItem `json:"contracts"`
+	Version   string              `json:"version"` // json encoded
+}


### PR DESCRIPTION
- Naming change (remove the J at the end of response as it's not JSON yet).
- Changed the response structure to allow for returning multiple compiled objects (contracts or libraries) and their respective abis.
- Godeps.json to Go 1.5.
- Implements conduit to provide multiple {bytecode, abi}s back the the compile client (for instance epm).
- Provide solidity libraries support.
- Changed server and client cache structure.
- Update tests.
- Added solc.go file (containing some solc relevant structures) for json unmarshalling.
- this requires a concerted change in eris-pm