### PR TITLE
silence logs for non CLI reasons

### DIFF
--- a/cmd/requestCompile.go
+++ b/cmd/requestCompile.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	cli "github.com/eris-ltd/eris-compilers/network"
+	"github.com/eris-ltd/eris-compilers/util"
 	"github.com/eris-ltd/eris-compilers/version"
 	log "github.com/eris-ltd/eris-logger"
-	"github.com/eris-ltd/eris-compilers/util"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/requestCompile.go
+++ b/cmd/requestCompile.go
@@ -9,6 +9,7 @@ import (
 	cli "github.com/eris-ltd/eris-compilers/network"
 	"github.com/eris-ltd/eris-compilers/version"
 	log "github.com/eris-ltd/eris-logger"
+	"github.com/eris-ltd/eris-compilers/util"
 
 	"github.com/spf13/cobra"
 )
@@ -38,10 +39,11 @@ var compileCmd = &cobra.Command{
 			os.Exit(0)
 		}
 		url := createUrl()
-		_, err := cli.BeginCompile(url, args[0], optimizeSolc, libraries)
+		output, err := cli.BeginCompile(url, args[0], optimizeSolc, libraries)
 		if err != nil {
 			log.Error(err)
 		}
+		util.PrintResponse(*output, true)
 	},
 }
 

--- a/network/client.go
+++ b/network/client.go
@@ -41,7 +41,6 @@ func BeginCompile(url string, file string, optimize bool, libraries string) (*ut
 		if err != nil {
 			return nil, err
 		}
-		util.PrintResponse(*resp)
 	} else {
 		log.Debug("Could not find cached object, compiling...")
 		if url == "" {
@@ -52,9 +51,10 @@ func BeginCompile(url string, file string, optimize bool, libraries string) (*ut
 				return nil, err
 			}
 		}
-		util.PrintResponse(*resp)
 		resp.CacheNewResponse(*request)
 	}
+
+	util.PrintResponse(*resp, false)
 
 	return resp, nil
 }

--- a/network/server.go
+++ b/network/server.go
@@ -77,8 +77,8 @@ func compileResponse(w http.ResponseWriter, r *http.Request) *util.Response {
 	log.WithFields(log.Fields{
 		"lang": req.Language,
 		// "script": string(req.Script),
-		"libs":   req.Libraries,
-		"incl":   req.Includes,
+		"libs": req.Libraries,
+		"incl": req.Includes,
 	}).Debug("New Request")
 
 	cached := util.CheckCached(req.Includes, req.Language)

--- a/network/server.go
+++ b/network/server.go
@@ -98,6 +98,6 @@ func compileResponse(w http.ResponseWriter, r *http.Request) *util.Response {
 		resp = util.Compile(req)
 		resp.CacheNewResponse(*req)
 	}
-	util.PrintResponse(*resp)
+	util.PrintResponse(*resp, false)
 	return resp
 }

--- a/tests/compilers_test.go
+++ b/tests/compilers_test.go
@@ -1,20 +1,19 @@
 package compilersTest
 
 import (
-	"testing"
-	"reflect"
-	"net/http/httptest"
-	"net/http"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
+	"reflect"
 	"strings"
+	"testing"
 
 	net "github.com/eris-ltd/eris-compilers/network"
 	"github.com/eris-ltd/eris-compilers/util"
 
 	"github.com/eris-ltd/common/go/common"
 )
-
 
 func TestRequestCreation(t *testing.T) {
 	var err error
@@ -23,15 +22,15 @@ func TestRequestCreation(t *testing.T) {
         uint8[5] memory foo3 = [1, 1, 1, 1, 1];
     }
 }`
-	var testMap = map[string]*util.IncludedFiles {
+	var testMap = map[string]*util.IncludedFiles{
 		"13db7b5ea4e589c03c4b09b692723247c4029ab59047957940b06e1611be66ba.sol": {
 			ObjectNames: []string{"c"},
-			Script: []byte(contractCode),
+			Script:      []byte(contractCode),
 		},
 	}
 
 	req, err := util.CreateRequest("simpleContract.sol", "", false)
-	if (err != nil) {
+	if err != nil {
 		t.Fatal(err)
 	}
 	if req.Libraries != "" {
@@ -52,7 +51,7 @@ func TestRequestCreation(t *testing.T) {
 func TestServerSingle(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(net.CompileHandler))
 	defer testServer.Close()
-	
+
 	expectedSolcResponse := util.BlankSolcResponse()
 
 	actualOutput, err := exec.Command("solc", "--combined-json", "bin,abi", "simpleContract.sol").Output()
@@ -61,7 +60,7 @@ func TestServerSingle(t *testing.T) {
 	}
 	output := strings.TrimSpace(string(actualOutput))
 	err = json.Unmarshal([]byte(output), expectedSolcResponse)
-	
+
 	respItemArray := make([]util.ResponseItem, 0)
 
 	for contract, item := range expectedSolcResponse.Contracts {
@@ -74,7 +73,7 @@ func TestServerSingle(t *testing.T) {
 	}
 	expectedResponse := &util.Response{
 		Objects: respItemArray,
-		Error: "",
+		Error:   "",
 	}
 	util.ClearCache(common.SolcScratchPath)
 	t.Log(testServer.URL)
@@ -101,7 +100,7 @@ func TestServerMulti(t *testing.T) {
 	}
 	output := strings.TrimSpace(string(actualOutput))
 	err = json.Unmarshal([]byte(output), expectedSolcResponse)
-	
+
 	respItemArray := make([]util.ResponseItem, 0)
 
 	for contract, item := range expectedSolcResponse.Contracts {
@@ -114,7 +113,7 @@ func TestServerMulti(t *testing.T) {
 	}
 	expectedResponse := &util.Response{
 		Objects: respItemArray,
-		Error: "",
+		Error:   "",
 	}
 	util.ClearCache(common.SolcScratchPath)
 	t.Log(testServer.URL)
@@ -144,7 +143,7 @@ func TestLocalMulti(t *testing.T) {
 	}
 	output := strings.TrimSpace(string(actualOutput))
 	err = json.Unmarshal([]byte(output), expectedSolcResponse)
-	
+
 	respItemArray := make([]util.ResponseItem, 0)
 
 	for contract, item := range expectedSolcResponse.Contracts {
@@ -157,7 +156,7 @@ func TestLocalMulti(t *testing.T) {
 	}
 	expectedResponse := &util.Response{
 		Objects: respItemArray,
-		Error: "",
+		Error:   "",
 	}
 	util.ClearCache(common.SolcScratchPath)
 	resp, err := net.BeginCompile("", "contractImport1.sol", false, "")
@@ -176,17 +175,17 @@ func TestLocalMulti(t *testing.T) {
 	util.ClearCache(common.SolcScratchPath)
 }
 
-func TestLocalSingle(t *testing.T) {	
+func TestLocalSingle(t *testing.T) {
 	util.ClearCache(common.SolcScratchPath)
 	expectedSolcResponse := util.BlankSolcResponse()
 
-	actualOutput, err := exec.Command("solc", "--combined-json", "bin,abi", "simpleContract.sol").Output(); 
+	actualOutput, err := exec.Command("solc", "--combined-json", "bin,abi", "simpleContract.sol").Output()
 	if err != nil {
 		t.Fatal(err)
 	}
 	output := strings.TrimSpace(string(actualOutput))
 	err = json.Unmarshal([]byte(output), expectedSolcResponse)
-	
+
 	respItemArray := make([]util.ResponseItem, 0)
 
 	for contract, item := range expectedSolcResponse.Contracts {
@@ -199,7 +198,7 @@ func TestLocalSingle(t *testing.T) {
 	}
 	expectedResponse := &util.Response{
 		Objects: respItemArray,
-		Error: "",
+		Error:   "",
 	}
 	util.ClearCache(common.SolcScratchPath)
 	resp, err := net.BeginCompile("", "simpleContract.sol", false, "")
@@ -216,7 +215,7 @@ func TestFaultyContract(t *testing.T) {
 	util.ClearCache(common.SolcScratchPath)
 	var expectedSolcResponse util.Response
 
-	actualOutput, err := exec.Command("solc", "--combined-json", "bin,abi", "faultyContract.sol").CombinedOutput(); 
+	actualOutput, err := exec.Command("solc", "--combined-json", "bin,abi", "faultyContract.sol").CombinedOutput()
 	err = json.Unmarshal(actualOutput, expectedSolcResponse)
 	t.Log(expectedSolcResponse.Error)
 	resp, err := net.BeginCompile("", "faultyContract.sol", false, "")
@@ -231,10 +230,10 @@ func TestFaultyContract(t *testing.T) {
 }
 
 func contains(s []util.ResponseItem, e util.ResponseItem) bool {
-    for _, a := range s {
-        if a == e {
-            return true
-        }
-    }
-    return false
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/util/cache.go
+++ b/util/cache.go
@@ -80,7 +80,7 @@ func (resp Response) CacheNewResponse(req Request) {
 		os.Chdir(cur)
 	}()
 	for fileDir, metadata := range req.Includes {
-		dir := path.Join(cacheLocation, strings.TrimRight(fileDir, "." + req.Language))
+		dir := path.Join(cacheLocation, strings.TrimRight(fileDir, "."+req.Language))
 		os.MkdirAll(dir, 0700)
 		objectNames := metadata.ObjectNames
 		for _, name := range objectNames {

--- a/util/fileHandling.go
+++ b/util/fileHandling.go
@@ -175,16 +175,25 @@ func createTemporaryFile(name string, code []byte) (*os.File, error) {
 	return file, nil
 }
 
-func PrintResponse(resp Response) {
+func PrintResponse(resp Response, cli bool) {
 	if resp.Error != "" {
 		log.Warn(resp.Error)
 	} else {
-		for _, r := range resp.Objects {
-			log.WithFields(log.Fields{
-				"name": r.Objectname,
-				"bin":  r.Bytecode,
-				"abi":  r.ABI,
-			}).Warn("Response")
+		for _, r := range resp.Objects {		
+			if cli {
+				log.WithFields(log.Fields{
+					"name": r.Objectname,
+					"bin":  r.Bytecode,
+					"abi":  r.ABI,
+				}).Warn("Response")
+			} else {
+				log.WithFields(log.Fields{
+					"name": r.Objectname,
+					"bin":  r.Bytecode,
+					"abi":  r.ABI,
+				}).Info("Response")
+			}
+
 		}
 	}
 }

--- a/util/fileHandling.go
+++ b/util/fileHandling.go
@@ -176,24 +176,20 @@ func createTemporaryFile(name string, code []byte) (*os.File, error) {
 }
 
 func PrintResponse(resp Response, cli bool) {
+	message := log.WithFields((log.Fields{
+					"name": r.Objectname,
+					"bin":  r.Bytecode,
+					"abi":  r.ABI,
+				})
 	if resp.Error != "" {
 		log.Warn(resp.Error)
 	} else {
 		for _, r := range resp.Objects {		
 			if cli {
-				log.WithFields(log.Fields{
-					"name": r.Objectname,
-					"bin":  r.Bytecode,
-					"abi":  r.ABI,
-				}).Warn("Response")
+				message.Warn("Response")
 			} else {
-				log.WithFields(log.Fields{
-					"name": r.Objectname,
-					"bin":  r.Bytecode,
-					"abi":  r.ABI,
-				}).Info("Response")
+				message.Info("Response")
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
* contributes to a fix for https://github.com/eris-ltd/eris-cli/issues/1067 in silencing the ABI and BIN outputs on default and flips them to verbose. 