### PR TITLE
version, util: bump 0.12.1; print ABI and bytecode only on debug

### DIFF
--- a/util/fileHandling.go
+++ b/util/fileHandling.go
@@ -184,7 +184,7 @@ func PrintResponse(resp Response) {
 				"name": r.Objectname,
 				"bin":  r.Bytecode,
 				"abi":  r.ABI,
-			}).Warn("Response")
+			}).Debug("Response")
 		}
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // keep this line last
-const VERSION = "0.12.0"
+const VERSION = "0.12.1"


### PR DESCRIPTION
see https://github.com/eris-ltd/eris-cli/issues/1082