### PR TITLE
changed all mentions of eris-cli to eris and added in docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ so you can start compiling smart contract language right out of the box with no 
 
 ## Installation
 
-`eris-compilers` is intended to run as a service in a docker container via [eris-cli](https://monax.io/docs/documentation/cli/). The server can be started with: `eris services start compilers`.
+`eris-compilers` is intended to run as a service in a docker container via [eris](https://monax.io/docs/documentation/cli/). The server can be started with: `eris services start compilers`.
 
 ### For Developers
 

--- a/cmd/eris-compilers.go
+++ b/cmd/eris-compilers.go
@@ -4,8 +4,8 @@ import (
 	"os"
 
 	"github.com/eris-ltd/eris-compilers/version"
-	
-	"github.com/eris-ltd/eris-cli/log"
+
+	"github.com/eris-ltd/eris/log"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/requestCompile.go
+++ b/cmd/requestCompile.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/eris-ltd/eris-compilers/perform"
 	"github.com/eris-ltd/eris-compilers/version"
-	"github.com/eris-ltd/eris-cli/log"
+	"github.com/eris-ltd/eris/log"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/startServer.go
+++ b/cmd/startServer.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	server "github.com/eris-ltd/eris-compilers/perform"
-	"github.com/eris-ltd/eris-cli/log"
+	"github.com/eris-ltd/eris/log"
 	"github.com/spf13/cobra"
 	"os"
 	"strconv"

--- a/definitions/compiler.go
+++ b/definitions/compiler.go
@@ -1,15 +1,15 @@
 package definitions
 
 import (
-	"fmt"
-	"encoding/hex"
 	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"path"
-	"strings"
 	"regexp"
+	"strings"
 
-	"github.com/eris-ltd/eris-cli/log"
+	"github.com/eris-ltd/eris/log"
 )
 
 type Compiler struct {
@@ -30,8 +30,6 @@ func (c *Compiler) CompilerRequest(file string, includes map[string]*IncludedFil
 		FileReplacement: hashFileReplacement,
 	}
 }
-
-
 
 // Find all matches to the include regex
 // Replace filenames with hashes

--- a/definitions/definitions.go
+++ b/definitions/definitions.go
@@ -1,6 +1,6 @@
 package definitions
 
-import "github.com/eris-ltd/eris-cli/config"
+import "github.com/eris-ltd/eris/config"
 
 // Compile request object
 type Request struct {

--- a/docs/docs_generator.go
+++ b/docs/docs_generator.go
@@ -1,0 +1,333 @@
+package docs
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+const FrontMatter = `---
+
+layout: single
+type: docs
+title: "Documentation | {{ .Description }} | {{ $name }}"
+
+---`
+
+type Entry struct {
+	Title          string
+	Template       *template.Template
+	Specifications []*Entry
+	Examples       []*Entry
+	Description    string
+	FileName       string
+	CmdEntryPoint  string
+	URL            string
+	BaseURL        string
+}
+
+func GenerateFileName(dir, s string) string {
+	return (dir + strings.Replace(strings.ToLower(s), " ", "_", -1) + ".md")
+}
+
+func GenerateTitleFromFileName(file string) string {
+	file = strings.Replace(file, "_", " ", -1)
+	file = strings.Replace(file, "-", " ", -1)
+	return strings.Title(strings.Replace(file, ".md", "", 1))
+}
+
+func GenerateFileNameFromGlob(dir, s string) string {
+	return (dir + strings.Replace(filepath.Base(s), " ", "_", -1))
+}
+
+func GenerateURLFromFileName(s string) string {
+	s = strings.Replace(s, "./", "/", 1)
+	return strings.Replace(s, ".md", "/", -1)
+}
+
+func GenerateCommandsTemplate() (*template.Template, error) {
+	handle_link := func(s string) string {
+		return (strings.Replace(s, ".md", "/", -1))
+	}
+
+	handle_file := func(s1, s2 string) string {
+		return strings.Replace((s1 + " " + s2 + ".md"), " ", "_", -1)
+	}
+
+	funcMap := template.FuncMap{
+		"title":       strings.Title,
+		"replace":     strings.Replace,
+		"chomp":       strings.TrimSpace,
+		"handle_file": handle_file,
+		"handle_link": handle_link,
+	}
+
+	var templateText = `{{- $name := .Command.CommandPath -}}` + FrontMatter + `
+
+# {{ $name }}
+
+{{ title .Command.Short }}
+
+{{ if .Command.Runnable }}## Usage
+
+` + "```bash\n{{ .Command.UseLine }}\n```" + `{{ end }}
+
+{{ if ne .Command.Long  "" }}## Synopsis
+
+{{ .Command.Long }}
+{{ end }}
+{{ $flags := .Command.NonInheritedFlags }}
+{{ if $flags.HasFlags }}## Options
+
+` + "```bash\n  {{ $flags.FlagUsages | chomp }}\n```" + `{{ end }}
+{{ $global_flags := .Command.InheritedFlags }}
+{{ if $global_flags.HasFlags }}## Options inherited from parent commands
+
+` + "```bash\n  {{ $global_flags.FlagUsages | chomp }}\n```" + `{{ end }}
+
+{{ if .Command.HasSubCommands }}# Subcommands
+{{ range .Command.Commands }}
+{{ if ne .Deprecated "" }}
+* [{{ $name }} {{ .Name }}]({{ .BaseURL }}{{ handle_file $name .Name | handle_link }}) - {{ .Short }}
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{ if .Command.HasParent }}{{ $parent := .Command.Parent }}## See Also
+* [{{ $parent.CommandPath }}]({{ .BaseURL }}{{ handle_file $parent.CommandPath "" | handle_link }}) - {{ $parent.Short }}
+{{ end }}
+
+{{ if ne .Command.Example "" }}# Quick Tips
+
+` + "```bash\n{{ .Command.Example }}\n```" + `{{ end }}
+
+{{ if ne (len .Entry.Examples) 0 }}# Examples
+{{ range .Entry.Examples }}
+* [{{ title .Title }}]({{ .URL }})
+{{- end }}
+{{ end }}
+
+{{ if ne (len .Entry.Specifications) 0 }}# Specifications
+{{ range .Entry.Specifications }}
+* [{{ title .Title }}]({{ .URL }})
+{{- end }}
+{{ end }}
+`
+
+	return template.New("docGenerator").Funcs(funcMap).Parse(templateText)
+}
+
+func GenerateEntries(dir, render_dir, description string) ([]*Entry, error) {
+	var entries []*Entry
+
+	if _, err := os.Stat(render_dir); os.IsNotExist(err) {
+		err = os.MkdirAll(render_dir, 0755)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	files := CollectEntries(dir)
+
+	for _, file := range files {
+		this_entry, err := GenerateEntry(file, dir, render_dir, description)
+		if err != nil {
+			return nil, err
+		} else {
+			entries = append(entries, this_entry)
+		}
+	}
+
+	return entries, nil
+}
+
+func CollectEntries(dir string) []string {
+	var newFiles []string
+
+	files, err := filepath.Glob(dir + "/*")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, file := range files {
+		f_info, err := os.Stat(file)
+
+		if err != nil {
+			panic(err)
+		}
+
+		if f_info.IsDir() {
+			newFiles = append(newFiles, CollectEntries(file)...)
+		} else {
+			if filepath.Ext(file) == ".md" {
+				newFiles = append(newFiles, file)
+			}
+		}
+	}
+
+	return newFiles
+}
+
+func GenerateEntry(file, dir, render_dir, description string) (*Entry, error) {
+	var err error
+
+	this_entry := &Entry{
+		FileName:    GenerateFileNameFromGlob(render_dir, file),
+		Title:       GenerateTitleFromFileName(filepath.Base(file)),
+		Description: description,
+	}
+
+	this_entry.URL = GenerateURLFromFileName(this_entry.FileName)
+
+	txt, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get template from docs generator
+	this_entry.Template, err = GenerateEntriesTemplate(txt)
+	if err != nil {
+		return nil, err
+	}
+
+	return this_entry, nil
+}
+
+func GenerateEntriesTemplate(txt []byte) (*template.Template, error) {
+	handle_link := func(s string) string {
+		return (strings.Replace(s, ".md", "/", -1))
+	}
+
+	handle_file := func(s1 string) string {
+		return strings.Replace((s1 + ".md"), " ", "_", -1)
+	}
+
+	insert_definition := func(file string, struc string) string {
+		txt, err := ioutil.ReadFile(filepath.Join("definitions", file))
+		if err != nil {
+			panic(err)
+		}
+		finder := regexp.MustCompile(fmt.Sprintf(`(?ms:^type %s struct {.*?^})`, struc))
+		return ("```go\n" + string(finder.Find(txt)) + "\n```")
+	}
+
+	insert_bash_lines := func(file string, linesToRead string) string {
+		var lines []byte
+		var line []byte
+		var start int
+		var stop int
+
+		fileInfo, err := os.Open(filepath.Join("docs", "tests", file))
+		if err != nil {
+			panic(err)
+		}
+		defer fileInfo.Close()
+
+		start, err = strconv.Atoi(strings.Split(linesToRead, "-")[0])
+		if strings.Contains(linesToRead, "-") {
+			stop, err = strconv.Atoi(strings.Split(linesToRead, "-")[1])
+		} else {
+			stop = start
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		r := bufio.NewReader(fileInfo)
+		for i := 1; ; i++ {
+			line, err = r.ReadBytes('\n')
+			if err != nil {
+				break
+			}
+			if i >= start && i <= stop {
+				lines = append(lines, line...)
+			}
+		}
+		if err != io.EOF {
+			panic(err)
+		}
+
+		return ("```bash\n" + string(lines) + "```")
+	}
+
+	insert_file := func(file string) string {
+		file = filepath.Join("docs", "tests", file)
+		ext := filepath.Ext(file)
+		switch ext {
+		case ".sol":
+			ext = ".javascript"
+		case ".yml":
+			ext = ".yaml"
+		}
+
+		ext = strings.Replace(ext, ".", "", 1)
+
+		txtB, err := ioutil.ReadFile(file)
+		if err != nil {
+			panic(err)
+		}
+
+		txt := string(txtB)
+		if !strings.HasSuffix(txt, "\n") {
+			txt = txt + "\n"
+		}
+
+		return ("```" + ext + "\n" + txt + "```") // TODO: add auto-curl text
+	}
+
+	funcMap := template.FuncMap{
+		"title":             strings.Title,
+		"replace":           strings.Replace,
+		"chomp":             strings.TrimSpace,
+		"handle_file":       handle_file,
+		"handle_link":       handle_link,
+		"insert_definition": insert_definition,
+		"insert_bash_lines": insert_bash_lines,
+		"insert_file":       insert_file,
+	}
+
+	var templateText = `{{- $name := .Title -}}` + FrontMatter + `
+
+` + string(txt) + `
+
+## Commands
+
+* [{{ .CmdEntryPoint }}]({{ .BaseURL }}{{ handle_file .CmdEntryPoint | handle_link }})
+
+{{ if ne (len .Examples) 0 }}# Examples
+{{ range .Examples }}
+* [{{ title .Title }}]({{ .URL }})
+{{- end }}
+{{ end }}
+
+{{ if ne (len .Specifications) 0 }}# Specifications
+{{ range .Specifications }}
+* [{{ title .Title }}]({{ .URL }})
+{{- end }}
+{{ end }}
+`
+
+	return template.New("entryGenerator").Funcs(funcMap).Parse(templateText)
+}
+
+func RenderEntry(this_entry *Entry) error {
+	out_file, err := os.Create(this_entry.FileName)
+	if err != nil {
+		return err
+	}
+	defer out_file.Close()
+
+	err = this_entry.Template.Execute(out_file, this_entry)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/docs/generator.go
+++ b/docs/generator.go
@@ -1,4 +1,4 @@
-package main
+package docs
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/eris-ltd/common/go/docs"
 	commands "github.com/eris-ltd/eris-compilers/cmd"
 	"github.com/eris-ltd/eris-compilers/version"
 
@@ -18,25 +17,25 @@ var Description = "Compilers Tooling"                                           
 var RenderDir = fmt.Sprintf("./docs/documentation/compilers/%s/", version.VERSION) // should be the "shortversion..."
 
 // The below variables should be updated only if necessary.
-var Specs = []*docs.Entry{}
-var Examples = []*docs.Entry{}
+var Specs = []*Entry{}
+var Examples = []*Entry{}
 var SpecsDir = "./docs/specs"
 var ExamplesDir = "./docs/examples"
 
 type Cmd struct {
 	Command     *cobra.Command
-	Entry       *docs.Entry
+	Entry       *Entry
 	Description string
 }
 
 func RenderFiles(cmdRaw *cobra.Command, tmpl *template.Template) error {
-	this_entry := &docs.Entry{
+	this_entry := &Entry{
 		Title:          cmdRaw.CommandPath(),
 		Specifications: Specs,
 		Examples:       Examples,
 		BaseURL:        strings.Replace(RenderDir, ".", "", 1),
 		Template:       tmpl,
-		FileName:       docs.GenerateFileName(RenderDir, cmdRaw.CommandPath()),
+		FileName:       GenerateFileName(RenderDir, cmdRaw.CommandPath()),
 	}
 
 	cmd := &Cmd{
@@ -56,7 +55,7 @@ func RenderFiles(cmdRaw *cobra.Command, tmpl *template.Template) error {
 			entry.Examples = cmd.Entry.Examples
 			entry.CmdEntryPoint = cmd.Entry.Title
 			entry.BaseURL = cmd.Entry.BaseURL
-			if err := docs.RenderEntry(entry); err != nil {
+			if err := RenderEntry(entry); err != nil {
 				return err
 			}
 		}
@@ -92,17 +91,17 @@ func main() {
 	}
 
 	// Generate specs and examples files.
-	Specs, err = docs.GenerateEntries(SpecsDir, (RenderDir + "specifications/"), Description)
+	Specs, err = GenerateEntries(SpecsDir, (RenderDir + "specifications/"), Description)
 	if err != nil {
 		panic(err)
 	}
-	Examples, err = docs.GenerateEntries(ExamplesDir, (RenderDir + "examples/"), Description)
+	Examples, err = GenerateEntries(ExamplesDir, (RenderDir + "examples/"), Description)
 	if err != nil {
 		panic(err)
 	}
 
 	// Get template from docs generator.
-	tmpl, err := docs.GenerateCommandsTemplate()
+	tmpl, err := GenerateCommandsTemplate()
 	if err != nil {
 		panic(err)
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,29 +1,27 @@
-hash: 5dbf0042ceaecba75107e86997668c2c4b36ad259f7dd37a7d89bedefa51bcc8
-updated: 2016-11-23T16:52:12.27526443-06:00
+hash: 5f28d5b83b600ce5b47222a668ae9a32e51ca52adff5fa853be9768bd4a6c04e
+updated: 2017-01-27T10:44:19.296900399-06:00
 imports:
 - name: github.com/bugsnag/bugsnag-go
-  version: 718a5c3648c101c24adc20b7d3fe0be7af35a17a
+  version: 0e0aea7fe7d3fa47be41fc8a0e3a92d9668a9020
   subpackages:
   - errors
 - name: github.com/bugsnag/panicwrap
   version: aa7703c9414b36d4e9b2e42e6c704d0bfae7db64
 - name: github.com/BurntSushi/toml
-  version: 99064174e013895bbd9b025c31100bd1d9b590ca
-- name: github.com/eris-ltd/common
-  version: 8ca15f5455104403db4202c995e2f6e161654c02
+  version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
+- name: github.com/eris-ltd/eris
+  version: 77f05ad6c05a5e2a4f96eccaf50039e44b8082ea
   subpackages:
-  - go/docs
+  - config
+  - log
 - name: github.com/eris-ltd/eris-cli
   version: 002c63e2d0850b33c279c29fee52dd30853e100d
   subpackages:
-  - config
   - version
-- name: github.com/eris-ltd/eris-logger
-  version: cb5a0fa6ec4162413cfd5abf070d4c508b30541d
 - name: github.com/fsnotify/fsnotify
-  version: bd2828f9f176e52d7222e565abb2d338d3f3c103
+  version: a904159b9206978bb6d53fcc7a769e5cd726c737
 - name: github.com/hashicorp/hcl
-  version: 99ce73d4fe576449f7a689d4fc2b2ad09a86bdaa
+  version: db4f0768927a665a06c32855186e1bc762bcc8f5
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -37,53 +35,39 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/kardianos/osext
   version: c2c54e542fb797ad986b31721e1baedf214ca413
-- name: github.com/kr/fs
-  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: 0723e352fa358f9322c938cc2dadda874e9151a9
+  version: b3b15ef068fd0b17ddf408a23669f20811d194d2
 - name: github.com/mitchellh/mapstructure
-  version: f3009df150dadf309fdee4a54ed65c124afad715
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: 45932ad32dfdd20826f5671da37a5f3ce9f26a8d
-- name: github.com/pkg/errors
-  version: 839d9e913e063e28dfd0e6c7b7512793e0a48be9
-- name: github.com/pkg/sftp
-  version: 4d0e916071f68db74f8a73926335f809396d6b42
+  version: a1f048ba24490f9b0674a67e1ce995d685cddf4a
 - name: github.com/spf13/afero
-  version: 52e4a6cfac46163658bd4f123c49b6ee7dc75f78
+  version: 72b31426848c6ef12a7a8e216708cb0d1530f074
   subpackages:
   - mem
-  - sftp
 - name: github.com/spf13/cast
-  version: 2580bc98dc0e62908119e4737030cc2fdfc45e4c
+  version: 56a7ecbeb18dde53c6db4bd96b541fd9741b8d44
 - name: github.com/spf13/cobra
-  version: 856b96dcb49d6427babe192998a35190a12c2230
+  version: c29ece4386f74084680e5e6d02d7b943ae630f63
 - name: github.com/spf13/jwalterweatherman
-  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  version: fa7ca7e836cf3a8bb4ebf799f472c12d7e903d66
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: a9a634f3de0a7529baded7ad6b0c7467d5c6eca7
 - name: github.com/spf13/viper
-  version: 80ab6657f9ec7e5761f6603320d3d58dfe6970f6
+  version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
 - name: github.com/tcnksm/go-gitconfig
-  version: 6411ba19847f20afe47f603328d97aaeca6def6f
-- name: golang.org/x/crypto
-  version: 1150b8bd09e53aea1d415621adae9bad665061a1
-  subpackages:
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
-  - ssh
+  version: d154598bacbf4501c095a309753c5d4af66caa81
 - name: golang.org/x/sys
-  version: c200b10b5d5e122be351b67af224adc6128af5bf
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 2556e8494a202e0b4008f70eda8cdb089b03fa50
+  version: ece019dcfd29abcf65d0d1dfe145e8faad097640
   subpackages:
   - transform
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,8 @@
 package: github.com/eris-ltd/eris-compilers
 import:
-- package: github.com/eris-ltd/common
-  subpackages:
-  - go/docs
-- package: github.com/eris-ltd/eris-cli
+- package: github.com/eris-ltd/eris
+  version: develop
   subpackages:
   - config
-- package: github.com/eris-ltd/eris-logger
+  - log
 - package: github.com/spf13/cobra

--- a/perform/client.go
+++ b/perform/client.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/eris-ltd/eris-compilers/definitions"
-	"github.com/eris-ltd/eris-cli/log"
+	"github.com/eris-ltd/eris/log"
 )
 
 // send an http request and wait for the response

--- a/perform/perform_compilation.go
+++ b/perform/perform_compilation.go
@@ -1,19 +1,19 @@
 package perform
 
 import (
-	"fmt"
 	"encoding/json"
-	"os/exec"
+	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
+	"os/exec"
 	"path"
+	"strings"
 
-	"github.com/eris-ltd/eris-compilers/util"
 	"github.com/eris-ltd/eris-compilers/definitions"
+	"github.com/eris-ltd/eris-compilers/util"
 
-	"github.com/eris-ltd/eris-cli/log"
-	"github.com/eris-ltd/eris-cli/config"
+	"github.com/eris-ltd/eris/config"
+	"github.com/eris-ltd/eris/log"
 )
 
 type Response struct {
@@ -131,7 +131,7 @@ func compile(req *definitions.Request) *Response {
 
 	var warning string
 	jsonBeginsCertainly := strings.Index(output, `{"contracts":`)
-	
+
 	if jsonBeginsCertainly > 0 {
 		warning = output[:jsonBeginsCertainly]
 		output = output[jsonBeginsCertainly:]
@@ -174,8 +174,8 @@ func compile(req *definitions.Request) *Response {
 	for _, re := range respItemArray {
 		log.WithFields(log.Fields{
 			"name": re.Objectname,
-			"bin":   re.Bytecode,
-			"abi":   re.ABI,
+			"bin":  re.Bytecode,
+			"abi":  re.ABI,
 		}).Debug("Response formulated")
 	}
 

--- a/perform/server.go
+++ b/perform/server.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/eris-ltd/eris-compilers/definitions"
 
-	"github.com/eris-ltd/eris-cli/config"
-	"github.com/eris-ltd/eris-cli/log"
+	"github.com/eris-ltd/eris/config"
+	"github.com/eris-ltd/eris/log"
 )
 
 // Start the compile server

--- a/tests/compilers_test.go
+++ b/tests/compilers_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eris-ltd/eris-compilers/perform"
 	"github.com/eris-ltd/eris-compilers/definitions"
+	"github.com/eris-ltd/eris-compilers/perform"
 	"github.com/eris-ltd/eris-compilers/util"
 
-	"github.com/eris-ltd/eris-cli/config"
+	"github.com/eris-ltd/eris/config"
 )
 
 func TestRequestCreation(t *testing.T) {


### PR DESCRIPTION
* helps get glide in cleanly in CLI 
* needed at some point, why not now? 
* We can now deprecate common
* Why not deprecate this while we're at it :P ? 