### PR TITLE
patch: write libraries parameters to temp file

### DIFF
--- a/util/compile.go
+++ b/util/compile.go
@@ -120,7 +120,15 @@ func Compile(req *Request) *Response {
 		log.WithField("Filepath of include: ", file.Name()).Debug("To Cache")
 	}
 
-	command := lang.Cmd(includes, req.Libraries, req.Optimize)
+	// PATCH: [ben] this is patched to address an issue with too many libraries being
+	// passed as a flag into the compiler.
+	libsFile, err := createTemporaryFile("eris-libs", []byte(req.Libraries))
+	if err != nil {
+		return compilerResponse("", "", "", err)
+	}
+	defer os.Remove(libsFile.Name())
+	command := lang.Cmd(includes, libsFile.Name(), req.Optimize)
+	// END-OF-PATCH
 	log.WithField("Command: ", command).Debug("Command Input")
 	hexCode, err := RunCommand(command...)
 	//cleanup

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,5 @@
 package version
 
+// patched for fixing solc error when passing too many libraries into the request
 // keep this line last
-const VERSION = "0.12.1"
+const VERSION = "0.12.2"


### PR DESCRIPTION
v0.12.2 
patch: write libraries parameters to temp fileto avoid solc error on too long parameter string
